### PR TITLE
fix: Add Playwright browser installation to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
       - name: Run full CI/CD pipeline
         run: npm run ci:full
 


### PR DESCRIPTION
## Problem
The deployment workflow (`deploy.yml`) was failing because it runs `npm run ci:full` which includes Playwright tests, but the Chromium browser was never installed in the workflow.

**Error**: `Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1193/chrome-linux/headless_shell`

## Solution
Added the missing `npx playwright install --with-deps chromium` step to the deployment workflow, matching the pattern already used in `ci.yml` (line 90).

## Testing
- [x] Fix matches existing CI workflow pattern
- [ ] Deployment workflow will run on release creation
- [ ] All smoke tests should pass in deployment validation

## Impact
- Unblocks Railway deployment workflow
- Ensures deployment validation tests run successfully
- No changes to application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)