### PR TITLE
fix: Specify Railway service name in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,8 @@ jobs:
           echo "Release: ${{ github.event.release.tag_name }}"
           echo "Commit: ${{ github.sha }}"
 
-          # Deploy using Railway CLI
-          railway up --detach
+          # Deploy using Railway CLI with service name
+          railway up --detach --service joshify
 
           echo "✅ Deployment initiated successfully"
 


### PR DESCRIPTION
## Fix Railway Deployment\n\nAdds `--service joshify` flag to handle projects with multiple services.\n\n**Error Fixed**: "Multiple services found. Please specify a service via the --service flag."\n\n✅ Ready for Railway deployment\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)