### PR TITLE
fix: Add --host flag to vite preview for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --host",
     "lint": "eslint src --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 50",
     "type-check": "tsc --noEmit",
     "test": "npm run test:smoke",


### PR DESCRIPTION
## Summary
Fixes Railway deployment crash by adding `--host` flag to `vite preview` command.

## Issue
Railway containers crash on startup with:
```
Error: spawn xdg-open ENOENT
```

Railway's container environment doesn't have `xdg-open` (browser opener) installed. Vite preview tries to automatically open a browser, causing the crash.

## Solution
Added `--host` flag to `vite preview` command in package.json:
```json
"preview": "vite preview --host"
```

The `--host` flag:
- Prevents automatic browser opening
- Exposes server to all network interfaces (required for Railway)
- Allows Railway to properly route traffic to the container

## Testing
- Local testing will verify the command works
- Railway deployment will validate the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)