### PR TITLE
fix: Disable browser auto-open in vite preview mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     port: 3000,
     open: true
   },
+  preview: {
+    open: false
+  },
   build: {
     outDir: 'dist',
     sourcemap: true


### PR DESCRIPTION
## Railway Container Fix (v2)

### Problem
- Railway containers still crashing with `Error: spawn xdg-open ENOENT`
- Previous fix (`--host` flag) didn't prevent browser auto-open behavior
- Vite's `open: true` config applies to both dev and preview modes

### Root Cause
The `--host` flag only controls network interface exposure, not browser opening behavior. The actual issue is in `vite.config.ts` where `server.open: true` causes vite to attempt browser opening in preview mode.

### Solution
Added dedicated `preview` section to vite config:
```typescript
preview: {
  open: false
}
```

This keeps auto-open enabled for local dev (`npm run dev`) while preventing it in preview mode (`npm run preview`).

### Testing
- ✅ CI pipeline passes (lint, type-check, build)
- ✅ Local preview works without opening browser
- ✅ Dev server still auto-opens browser as expected

### Impact
- Railway containers will start successfully without xdg-open
- Dev experience unchanged for local development
- Canvas videos remain functional via GitHub Releases CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)