### PR TITLE
fix: Configure allowed hosts for Railway and custom domain

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
     open: true
   },
   preview: {
-    open: false
+    open: false,
+    host: true,
+    allowedHosts: [
+      'joshify-production.up.railway.app',
+      'www.joshify.dev',
+      'joshify.dev'
+    ]
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
Fixes "Blocked request" error when accessing Railway production deployment by adding allowed hosts configuration to Vite preview mode.

## Changes
- Add `allowedHosts` to `vite.config.ts` preview configuration
- Support Railway production URL: `joshify-production.up.railway.app`
- Support custom domain with www: `www.joshify.dev`
- Support custom domain without www: `joshify.dev`
- Enable `host: true` for network binding

## Test Plan
- [x] CI checks pass (lint, type-check, build)
- [ ] Railway deployment accepts requests
- [ ] Custom domain ready for future DNS configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)