### PR TITLE
feat: set Joshify as default now playing project

### DIFF
--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -23,11 +23,11 @@ const usePlayer = () => {
         setSearchQuery
     );
 
-    // Set "Did Kansas Win?" as default "now playing" on load
+    // Set "Joshify" as default "now playing" on load
     useEffect(() => {
-        const didKansasWin = projects.find(p => p.id === 'did-kansas-win');
-        if (didKansasWin && !currentlyPlaying) {
-            setCurrentlyPlaying(didKansasWin);
+        const joshify = projects.find(p => p.id === 'joshify');
+        if (joshify && !currentlyPlaying) {
+            setCurrentlyPlaying(joshify);
             setIsPlaying(true);
         }
     }, [currentlyPlaying]);


### PR DESCRIPTION
Changed the default now playing project from "Did Kansas Win?" to "Joshify" to showcase the portfolio project itself when users first load the site.

Changes:
- Updated usePlayer.ts to set 'joshify' as initial currentlyPlaying project
- Updated comment to reflect new default project

🤖 Generated with [Claude Code](https://claude.com/claude-code)