### PR TITLE
fix: prevent mobile modal from covering bottom player

### DIFF
--- a/src/components/views/ProjectDetailView.tsx
+++ b/src/components/views/ProjectDetailView.tsx
@@ -166,7 +166,7 @@ const ProjectDetailView = ({
     return (
         <div className="relative text-white md:p-6">
             {/* Mobile: Full-screen modal with slide-up animation */}
-            <div className="md:hidden fixed inset-0 z-50 bg-black animate-slide-up">
+            <div className="md:hidden fixed inset-x-0 top-0 bottom-24 z-50 bg-black animate-slide-up">
                 {/* Canvas Background */}
                 <div className="absolute inset-0 z-0">
                     <ProjectCanvas


### PR DESCRIPTION
## Summary
Fixed mobile viewport bug where the project detail modal covered the bottom player, making it inaccessible.

## Problem
The mobile modal used `fixed inset-0 z-50`, which covered the entire viewport including the bottom player (h-24 = 96px). Users couldn't access playback controls when viewing project details on mobile.

## Solution
Changed modal positioning from `inset-0` to `inset-x-0 top-0 bottom-24`:
- Modal now stops 96px from the bottom of the viewport
- Bottom player remains fully visible and interactive
- Content within modal is scrollable with `pb-32` padding at bottom

## Changes
- `src/components/views/ProjectDetailView.tsx`: Updated mobile modal container class

## Testing
Verified on multiple mobile viewport sizes:
- ✅ iPhone SE (375x667)
- ✅ iPhone 11 Pro Max (414x896)  
- ✅ Galaxy S5 (360x640)
- ✅ Modal content scrolls properly
- ✅ Player controls fully accessible

## CI Status
- ✅ Lint passed
- ✅ Type check passed
- ✅ Build passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)