### PR TITLE
fix: use 100dvh to account for mobile browser chrome

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,10 +89,11 @@ const SpotifyResume = () => {
 
     return (
         <div
-            className="flex flex-col h-screen bg-spotify-black text-spotify-primary overflow-hidden"
+            className="flex flex-col bg-spotify-black text-spotify-primary overflow-hidden"
             style={{
         '--left-sidebar-width': `${leftColumnWidth}px`,
-        '--right-sidebar-width': `${rightColumnWidth}px`
+        '--right-sidebar-width': `${rightColumnWidth}px`,
+        height: '100dvh'
       } as React.CSSProperties}
     >
             {/* Top Bar - Full Width */}


### PR DESCRIPTION
## Summary
Fixed mobile viewport issue where the bottom player was pushed below the visible area on real mobile devices due to browser UI chrome (address bar + navigation buttons).

## Problem
**Root Cause:** Mobile browsers display UI chrome (address bar at top, navigation buttons at bottom) that takes ~100-120px of space. Using `h-screen` (100vh) for the app container caused the layout to be 100% of the "full" viewport height, but this doesn't account for browser chrome. Result: The bottom player (96px tall) was pushed below the visible area.

**User Impact:** On real mobile devices, users couldn't access playback controls because the bottom player was cut off below the viewport.

**Why Previous Fix Didn't Work:** PR #29 fixed the modal covering the player, but the underlying issue was that the entire app was taller than the visible viewport. The real problem was using `100vh` instead of `100dvh`.

## Solution
Changed from `h-screen` (Tailwind class = `height: 100vh`) to inline style `height: 100dvh`:

```tsx
// Before
className="flex flex-col h-screen ..."

// After  
className="flex flex-col ..."
style={{ height: '100dvh', ... }}
```

**What is `dvh`?**
- `dvh` = "dynamic viewport height" 
- Specifically designed for this mobile browser chrome issue
- Automatically accounts for visible viewport space
- On mobile: `100dvh < 100vh` (excludes browser chrome)
- On desktop: `100dvh = 100vh` (no browser chrome)

## Changes
- `src/App.tsx`: Removed `h-screen` class, added `height: '100dvh'` to inline style

## Testing
**Playwright Limitation:** 
Playwright shows `100dvh = 844px` (same as `100vh`) because it's a headless browser without UI chrome. This is expected behavior.

**Real Mobile Testing Required:**
The fix must be verified on actual mobile devices where:
- Chrome/Safari will apply browser UI chrome
- `100dvh` will be smaller than `100vh`
- Bottom player will remain fully visible

**Expected Behavior:**
- ✅ App container height matches visible viewport (excluding browser chrome)
- ✅ Bottom player stays within visible area  
- ✅ No scrolling needed to access player controls
- ✅ Works on all mobile devices (iOS/Android)

## Related
- PR #29: Fixed modal covering player (still needed, works with this fix)
- This fix addresses the root cause of the mobile player viewport issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)