### PR TITLE
fix: add z-index to prevent content scrolling over bottom player

### DIFF
--- a/src/components/BottomPlayer.tsx
+++ b/src/components/BottomPlayer.tsx
@@ -28,7 +28,7 @@ const BottomPlayer = ({
     const canGoNext = currentPlaylist && currentTrackIndex < (currentPlaylist.projects?.length - 1);
 
     return (
-        <div className="h-24 bg-black flex items-center px-4">
+        <div className="h-24 bg-black flex items-center px-4 relative z-40">
             {currentlyPlaying ? (
                 <>
                     {/* Left: Now Playing Info */}


### PR DESCRIPTION
## Summary
Fixed z-index layering issue where scrolling content (especially project descriptions on detail pages) was appearing in front of the bottom player instead of behind it.

## Problem
The BottomPlayer component had no z-index specified, giving it the default stacking context. When users scrolled on project detail pages, the content would scroll over the player text, making it unreadable.

## Solution
Added `relative z-40` to the BottomPlayer container:
- `relative`: Required for z-index to take effect
- `z-40`: Matches the app's z-index hierarchy (same as mobile sidebar overlay)

## Z-Index Hierarchy
- `z-50`: Modals (AlbumArtModal, mobile sidebar)
- `z-40`: Bottom player, overlays (now fixed)
- `z-10`: Misc UI elements
- `z-0`: Default (scrolling content)

This ensures:
- ✅ Bottom player stays visible above scrolling content
- ✅ Modals (z-50) can still appear on top when needed
- ✅ Consistent with app's existing z-index strategy

## Changes
- `src/components/BottomPlayer.tsx`: Added `relative z-40` classes

## Testing
- ✅ Lint passed
- ✅ Type check passed
- ✅ Build passed
- ✅ Should verify on mobile: scroll project detail page, player stays on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)