### PR TITLE
fix: increase bottom player z-index to prevent content overlap on mobile

### DIFF
--- a/src/components/BottomPlayer.tsx
+++ b/src/components/BottomPlayer.tsx
@@ -28,7 +28,7 @@ const BottomPlayer = ({
     const canGoNext = currentPlaylist && currentTrackIndex < (currentPlaylist.projects?.length - 1);
 
     return (
-        <div className="h-24 bg-black flex items-center px-4 relative z-40">
+        <div className="h-24 bg-black flex items-center px-4 relative z-[60]">
             {currentlyPlaying ? (
                 <>
                     {/* Left: Now Playing Info */}


### PR DESCRIPTION
## Summary
- Fixed mobile project detail pages where scrolling content was appearing on top of the bottom player
- Increased BottomPlayer z-index from `z-40` to `z-[60]` to ensure it stays above the mobile modal (`z-50`)

## Root Cause
The mobile project detail modal had `z-50` while the bottom player had `z-40`, causing the player to render beneath scrolling content.

## Changes
- `src/components/BottomPlayer.tsx`: Changed z-index from `z-40` to `z-[60]`

## Testing
- ✅ Tested locally with Playwright MCP in mobile viewport (375x667)
- ✅ Verified player now has z-index 60 (higher than modal's z-50)
- ✅ Confirmed all content is accessible with existing `pb-32` padding
- ✅ Scrolled to bottom to ensure no content is hidden behind player
- ✅ Player remains visible and on top during scroll
- ✅ CI checks pass (lint, type-check, build)

## Screenshots
Mobile view with content scrolled to bottom - player correctly stays on top:
![mobile-absolute-bottom](https://github.com/user-attachments/assets/mobile-absolute-bottom.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)