### PR TITLE
Add Welcome modal popup for new visitors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import usePlayer from '@/hooks/usePlayer';
 import useColumnResize from '@/hooks/useColumnResize';
 import useDynamicBackground from '@/hooks/useDynamicBackground';
@@ -15,8 +15,22 @@ import ProjectDetailView from '@/components/views/ProjectDetailView';
 import SearchView from '@/components/views/SearchView';
 import CompanyView from '@/components/views/CompanyView';
 import DomainView from '@/components/views/DomainView';
+import WelcomeModal from '@/components/WelcomeModal';
 
 const SpotifyResume = () => {
+    // Welcome modal state - show on first visit
+    const [showWelcome, setShowWelcome] = useState(() => {
+        return !localStorage.getItem('joshify_welcome_seen');
+    });
+
+    const handleWelcomeClose = () => {
+        setShowWelcome(false);
+        localStorage.setItem('joshify_welcome_seen', 'true');
+    };
+
+    const handleShowWelcome = () => {
+        setShowWelcome(true);
+    };
     const {
         currentlyPlaying,
         isPlaying,
@@ -125,6 +139,7 @@ const SpotifyResume = () => {
                         onNavigateToPlaylist={navigateToPlaylist}
                         onNavigateToProject={navigateToProject}
                         onCloseSidebar={closeSidebar}
+                        onShowWelcome={handleShowWelcome}
                         width={leftColumnWidth}
                         mode={leftColumnMode}
                         style={isLeftResizing ? {} : { width: `${leftColumnWidth}px` }}
@@ -246,6 +261,12 @@ const SpotifyResume = () => {
                 currentPlaylist={currentPlaylist}
                 currentTrackIndex={currentTrackIndex}
       />
+
+            {/* Welcome Modal */}
+            <WelcomeModal
+                isOpen={showWelcome}
+                onClose={handleWelcomeClose}
+            />
         </div>
     );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, Info } from 'lucide-react';
 import { playlists, projects } from '../data/projects';
 import type { Playlist } from '../types';
 
@@ -10,6 +10,7 @@ interface SidebarProps {
   onNavigateToPlaylist: (_playlist: Playlist) => void;
   onNavigateToProject: (_project: any) => void;
   onCloseSidebar: () => void;
+  onShowWelcome: () => void;
   width?: number;
   mode?: string;
   style?: Record<string, any>;
@@ -24,6 +25,7 @@ const Sidebar = ({
     onNavigateToPlaylist,
     onNavigateToProject,
     onCloseSidebar,
+    onShowWelcome,
     width: _width = 256,
     mode = 'normal',
     style = {}
@@ -98,7 +100,7 @@ const Sidebar = ({
     return (
         <div 
             data-sidebar
-            className={`fixed md:relative inset-y-0 left-0 z-50 bg-spotify-dark ${isIconMode ? 'pl-1 pr-0 py-2 md:pl-2 md:pr-0 md:py-3' : 'pl-1 pr-0 py-2 md:pl-1.5 md:pr-0 md:py-3'} flex flex-col transform transition-all duration-300 ease-in-out ${
+            className={`fixed md:relative inset-y-0 left-0 z-50 bg-spotify-dark ${isIconMode ? 'pl-1 pr-0 py-2 md:pl-2 md:pr-0 md:py-3' : 'pl-1 pr-0 py-2 md:pl-1.5 md:pr-0 md:py-3'} pb-24 md:pb-3 flex flex-col transform transition-all duration-300 ease-in-out ${
       sidebarOpen ? 'translate-x-0' : '-translate-x-full'
     } md:translate-x-0 md:rounded-t-lg md:h-full`}
             style={{
@@ -257,6 +259,22 @@ const Sidebar = ({
           )
         )}
                 </div>
+            </div>
+
+            {/* About Joshify Link */}
+            <div className={`mt-2 pt-2 border-t border-spotify-hover ${isIconMode ? 'px-1' : 'px-2'}`}>
+                <button
+                    onClick={onShowWelcome}
+                    className={`flex items-center w-full text-left rounded-md text-spotify-secondary hover:text-spotify-primary hover:bg-spotify-hover transition-colors ${
+                        isIconMode ? 'justify-center py-3 px-1' : 'space-x-3 py-2 px-2'
+                    }`}
+                    title={isIconMode ? 'About Joshify' : undefined}
+                >
+                    <Info className="w-5 h-5 flex-shrink-0" />
+                    {!isIconMode && (
+                        <span className="text-sm font-medium">About Joshify</span>
+                    )}
+                </button>
             </div>
         </div>
     );

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,0 +1,91 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+
+interface WelcomeModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const WelcomeModal = ({ isOpen, onClose }: WelcomeModalProps) => {
+    // Handle escape key press to close modal
+    useEffect(() => {
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('keydown', handleEscape);
+            // Prevent body scroll when modal is open
+            document.body.style.overflow = 'hidden';
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleEscape);
+            document.body.style.overflow = 'unset';
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+            {/* Backdrop */}
+            <div
+                className="absolute inset-0 bg-black bg-opacity-80 backdrop-blur-sm"
+                onClick={onClose}
+            />
+
+            {/* Modal Content */}
+            <div className="relative z-10 mx-4 w-full max-w-md">
+                <div className="bg-spotify-card rounded-lg p-6 shadow-2xl">
+                    {/* Close Button */}
+                    <button
+                        onClick={onClose}
+                        className="absolute top-4 right-4 w-8 h-8 bg-spotify-hover rounded-full flex items-center justify-center text-spotify-secondary hover:text-spotify-primary hover:bg-spotify-lightgray transition-colors"
+                        aria-label="Close welcome modal"
+                    >
+                        <X className="w-4 h-4" />
+                    </button>
+
+                    {/* Content */}
+                    <div className="text-center">
+                        <h2 className="text-2xl font-bold text-spotify-primary mb-4">
+                            Welcome to Joshify!
+                        </h2>
+
+                        <p className="text-spotify-secondary mb-4">
+                            This is my portfolio reimagined as a Spotify clone.
+                            Each project is presented as a &apos;track&apos;, complete with album art and
+                            immersive canvas backgrounds.
+                        </p>
+
+                        <p className="text-spotify-secondary mb-6">
+                            Browse collections, explore individual projects, and enjoy the
+                            familiar interface.
+                        </p>
+
+                        <p className="text-spotify-secondary mb-4">
+                            One thing - the site doesn&apos;t actually have any music... <i>yet</i>.
+                        </p>
+
+                        <p className="text-sm text-spotify-secondary mb-6">
+                            You can always revisit this by clicking &quot;About Joshify&quot; in the sidebar.
+                        </p>
+
+                        {/* Get Started Button */}
+                        <button
+                            onClick={onClose}
+                            className="w-full py-3 px-6 bg-spotify-green text-black font-bold rounded-full hover:scale-105 hover:bg-[#1ed760] transition-all"
+                        >
+                            Got it!
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default WelcomeModal;


### PR DESCRIPTION
<!--
1. Make sure your branch is named with this format: `user/description-ticket`
2. Update the PR title: `[JIRA-1337] Foobinator: Add Awesomeness`
-->

#### Fixes JIRA-1234

### Background

User research revealed that some users, upon first visiting the site, were a little disoriented and not sure what they were looking at. It looked like Spotify, but wasn't. I reasoned that a one time pop-up modal welcoming new users to the site made sense to address that UX problem.

### Technical Highlights

- Uses localStorage as opposed to cookies to attempt to track first time visitors
- Modal window matches the Spotify UI of the rest of the site
- Includes a way for users who have seen and closed the welcome popup to reopen it

### Validation

Tested locally in both mobile and desktop orientation. Opening the site twice in the same browser window, the popup only appears once. Opening the site in an incognito window, the popup appears again with each new incognito window.

If this had been more of a backend fix, say, verifiable by cURLing an API endpoint, I'd do something like this:

_Here's where I tested the new "completed" field:_
```bash
$ curl -s https://jsonplaceholder.typicode.com/todos | jq '.[1:4]'
[
  {
    "userId": 1,
    "id": 2,
    "title": "quis ut nam facilis et officia qui",
    "completed": false
  },
  {
    "userId": 1,
    "id": 3,
    "title": "fugiat veniam minus",
    "completed": false
  },
  {
    "userId": 1,
    "id": 4,
    "title": "et porro tempora",
    "completed": true
  }
]
```

### Documentation

Hahaha this project doesn't have documentation, silly. Well, beyond the README.md, which I did not update. This functionality doesn't need much explanation.

### ETL Requirements

Does this PR require the ETL process or migrations to be executed before the next API release?

- [ ] Yes (please add the ETL or Migrations label to the PR)
- [x] No