### PR TITLE
feat: add expand indicator to mobile player bar

### DIFF
--- a/src/components/BottomPlayer.tsx
+++ b/src/components/BottomPlayer.tsx
@@ -1,4 +1,4 @@
-import { Play, Pause, Volume2, Shuffle, Repeat, SkipBack, SkipForward } from 'lucide-react';
+import { Play, Pause, Volume2, Shuffle, Repeat, SkipBack, SkipForward, ChevronUp } from 'lucide-react';
 import ProjectImage from './ProjectImage';
 import type { Project, Playlist } from '../types';
 
@@ -29,6 +29,18 @@ const BottomPlayer = ({
 
     return (
         <div className="h-24 bg-black flex items-center px-4 relative z-[60]">
+            {/* Mobile expand indicator - tap to view project details */}
+            {currentlyPlaying && (
+                <div className="md:hidden absolute top-1 left-0 right-0 flex justify-center z-10">
+                    <button
+                        onClick={() => onNavigateToProject(currentlyPlaying)}
+                        className="p-2 hover:bg-white/10 rounded-full transition-colors"
+                        aria-label="View project details"
+                    >
+                        <ChevronUp className="w-8 h-8 text-white" />
+                    </button>
+                </div>
+            )}
             {currentlyPlaying ? (
                 <>
                     {/* Left: Now Playing Info */}


### PR DESCRIPTION
## Summary
- Add ChevronUp icon to mobile bottom player bar
- Mirrors the ChevronDown collapse button in expanded project detail view
- Provides visual affordance that tapping the player expands to show project details
- Clickable to trigger expansion

## Test plan
- [ ] View site on mobile viewport
- [ ] Verify ChevronUp appears centered at top of player bar when a project is selected
- [ ] Verify tapping the icon expands to project detail view
- [ ] Verify ChevronDown in expanded view matches styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)