### PR TITLE
fix: update Recently Played description year to 2026

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -482,7 +482,7 @@ export const playlists: PlaylistCollection = [
         name: 'Recently Played',
         icon: Clock,
         projects: recentWork,
-        description: 'Fresh out the studio. Latest work from 2024-2025.',
+        description: 'Fresh out the studio. Latest work from 2024-2026.',
         image: null,
         employer: false
     },


### PR DESCRIPTION
## Summary
- Update year range in Recently Played playlist description from 2024-2025 to 2024-2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)