### PR TITLE
fix: prevent mobile lyrics text overflow on scale

### DIFF
--- a/src/components/MobilePlayerView.tsx
+++ b/src/components/MobilePlayerView.tsx
@@ -179,7 +179,8 @@ const MobilePlayerView = ({
                                         key={index}
                                         ref={setMobileLineRef(index)}
                                         className={`
-                                            text-2xl font-bold leading-loose
+                                            text-2xl font-bold leading-tight mb-5
+                                            max-w-[77%]
                                             transition-all duration-500 ease-out origin-left
                                             ${isActive ? 'text-white scale-[1.3]' : isPast ? 'text-white/40 scale-100' : 'text-white/40 scale-100'}
                                         `}
@@ -378,7 +379,8 @@ const MobilePlayerView = ({
                                             key={index}
                                             ref={setPreviewLineRef(index)}
                                             className={`
-                                                text-xl font-bold leading-relaxed
+                                                text-xl font-bold leading-tight mb-5
+                                                max-w-[77%]
                                                 transition-all duration-500 ease-out origin-left
                                                 ${isActive ? 'text-white scale-[1.3]' : isPast ? 'text-white/40 scale-100' : 'text-white/40 scale-100'}
                                             `}


### PR DESCRIPTION
## Summary
- Constrain mobile lyrics text to 77% max-width so active line's 1.3x scale doesn't push text off-screen (77% × 1.3 ≈ 100%)
- Switch to tight line-height (`leading-tight`) for snug wrapped-line spacing within a lyric
- Add `mb-5` between lyric lines for clear separation, matching Spotify's mobile lyrics layout

## Test plan
- [ ] Open mobile player view, play a track with long lyric lines
- [ ] Verify active (scaled) lines stay within viewport
- [ ] Verify wrapped lines sit close together, separate lyrics have clear spacing
- [ ] Check both expanded lyrics view and inline lyrics preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)