### PR TITLE
fix: mobile viewport height and playlist play/pause toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon.svg" />
     <link rel="icon" type="image/svg+xml" sizes="32x32" href="/favicon.svg" />
     <link rel="icon" type="image/svg+xml" sizes="16x16" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Joshify - Josh's Developer Portfolio</title>
     <meta name="description" content="Josh's developer portfolio designed as a Spotify-like music streaming interface, showcasing projects as albums." />
 
@@ -30,6 +30,15 @@
 </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Set --app-height from window.innerHeight to reliably account for
+      // mobile browser chrome (address bar, bottom nav) on initial load.
+      function setAppHeight() {
+        document.documentElement.style.setProperty('--app-height', window.innerHeight + 'px');
+      }
+      setAppHeight();
+      window.addEventListener('resize', setAppHeight);
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,7 +224,7 @@ const SpotifyResume = () => {
             style={{
         '--left-sidebar-width': `${leftColumnWidth}px`,
         '--right-sidebar-width': `${rightColumnWidth}px`,
-        height: '100dvh'
+        height: 'var(--app-height, 100dvh)'
       } as React.CSSProperties}
     >
             {/* Top Bar - Full Width */}
@@ -316,7 +316,9 @@ const SpotifyResume = () => {
                                         playlist={selectedPlaylist}
                                         currentlyPlaying={currentlyPlaying}
                                         isPlaying={isPlaying}
+                                        currentPlaylist={currentPlaylist}
                                         onPlayProject={handlePlayProject}
+                                        onTogglePlay={handleTogglePlay}
                                         onNavigateToProject={navigateToProject}
                                         onNavigateToCompany={navigateToCompany}
                                         onNavigateToDomain={navigateToDomain}
@@ -371,7 +373,9 @@ const SpotifyResume = () => {
                                         playlist={likedSongsPlaylist}
                                         currentlyPlaying={currentlyPlaying}
                                         isPlaying={isPlaying}
+                                        currentPlaylist={currentPlaylist}
                                         onPlayProject={handlePlayProject}
+                                        onTogglePlay={handleTogglePlay}
                                         onNavigateToProject={navigateToProject}
                                         onNavigateToCompany={navigateToCompany}
                                         onNavigateToDomain={navigateToDomain}

--- a/src/components/BottomPlayer.tsx
+++ b/src/components/BottomPlayer.tsx
@@ -128,7 +128,7 @@ const BottomPlayer = ({
     }
 
     return (
-        <div className="bg-black relative z-[60]">
+        <div className="bg-black relative z-[60]" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
             {/* Mobile Player Bar */}
             <div className="md:hidden">
                 {/* Clickable area (excludes play button) */}

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -1,5 +1,5 @@
 
-import { Play, Heart } from 'lucide-react';
+import { Play, Pause, Heart } from 'lucide-react';
 import ProjectImage from '../ProjectImage';
 import PlaylistCoverArt from '../PlaylistCoverArt';
 import type { Playlist, Project } from '../../types';
@@ -8,7 +8,9 @@ interface PlaylistViewProps {
   playlist: Playlist;
   currentlyPlaying: Project | null;
   isPlaying: boolean;
+  currentPlaylist: Playlist | null;
   onPlayProject: (_project: Project, _playlist?: Playlist | null) => void;
+  onTogglePlay: () => void;
   onNavigateToProject: (_project: Project) => void;
   onNavigateToCompany?: (_companyName: string) => void;
   onNavigateToDomain?: (_domainName: string) => void;
@@ -19,8 +21,10 @@ interface PlaylistViewProps {
 const PlaylistView = ({
     playlist,
     currentlyPlaying,
-    isPlaying: _isPlaying,
+    isPlaying,
+    currentPlaylist,
     onPlayProject,
+    onTogglePlay,
     onNavigateToProject,
     onNavigateToCompany,
     onNavigateToDomain: _onNavigateToDomain,
@@ -49,19 +53,30 @@ const PlaylistView = ({
         </div>
 
         <div className="flex items-center space-x-4 md:space-x-6 mb-6 md:mb-8">
-            <button 
-                className="w-12 h-12 md:w-14 md:h-14 bg-green-500 rounded-full flex items-center justify-center hover:scale-105 transition-transform"
-                onClick={() => {
-          if (playlist.projects.length > 0) {
-            const firstProject = playlist.projects[0];
-            if (firstProject) {
-              onPlayProject(firstProject, playlist);
-            }
-          }
-        }}
-      >
-                <Play className="w-5 h-5 md:w-6 md:h-6 text-black ml-0.5" fill="currentColor" />
-            </button>
+            {(() => {
+                const isThisPlaylistActive = currentPlaylist?.name === playlist.name && playlist.projects.some(p => p.id === currentlyPlaying?.id);
+                return (
+                    <button
+                        className="w-12 h-12 md:w-14 md:h-14 bg-green-500 rounded-full flex items-center justify-center hover:scale-105 transition-transform"
+                        onClick={() => {
+                            if (isThisPlaylistActive) {
+                                onTogglePlay();
+                            } else if (playlist.projects.length > 0) {
+                                const firstProject = playlist.projects[0];
+                                if (firstProject) {
+                                    onPlayProject(firstProject, playlist);
+                                }
+                            }
+                        }}
+                    >
+                        {isThisPlaylistActive && isPlaying ? (
+                            <Pause className="w-5 h-5 md:w-6 md:h-6 text-black" fill="currentColor" />
+                        ) : (
+                            <Play className="w-5 h-5 md:w-6 md:h-6 text-black ml-0.5" fill="currentColor" />
+                        )}
+                    </button>
+                );
+            })()}
         </div>
 
         {/* Desktop Table View */}


### PR DESCRIPTION
## Summary
- Fix mobile player bar disappearing behind browser chrome on page reload by using JS-based `window.innerHeight` instead of `100dvh`
- Add `viewport-fit=cover` and `env(safe-area-inset-bottom)` for devices with home indicators
- Playlist view big play button now toggles to pause when that playlist is actively playing, and resumes on click

## Test plan
- [ ] Reload site on mobile — player bar stays visible above browser navigation
- [ ] Play a song from a playlist — big green button shows pause icon
- [ ] Pause — button reverts to play icon
- [ ] Click play again — resumes (doesn't restart from first track)
- [ ] Navigate to a different playlist — button shows play icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)